### PR TITLE
tuple expression not allowed in type annotation

### DIFF
--- a/persiantools/digits.py
+++ b/persiantools/digits.py
@@ -1,4 +1,5 @@
 from persiantools import utils
+from typing import Union
 
 EN_TO_FA_MAP = {
     "0": "۰",
@@ -183,7 +184,7 @@ def _floating_number_to_word(number: float, depth: bool) -> str:
         return _to_word(int(left), False)
 
 
-def to_word(number: (float, int)) -> str:
+def to_word(number: Union[float, int]) -> str:
     if isinstance(number, int):
         return _to_word(number, False)
     elif isinstance(number, float):

--- a/persiantools/digits.py
+++ b/persiantools/digits.py
@@ -1,5 +1,6 @@
-from persiantools import utils
 from typing import Union
+
+from persiantools import utils
 
 EN_TO_FA_MAP = {
     "0": "۰",


### PR DESCRIPTION
due to https://docs.python.org/3/whatsnew/3.10.html#new-features-related-to-type-hints
type hints can now be written in a more succinct manner (number: int | float) -> int | float