### PR TITLE
Added `strptime` support to `JalaliDate` for parsing date strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## [5.3.0](https://github.com/majiidd/persiantools/compare/5.2.1...5.3.0) - 2025-06-06
+
+- Added `strptime` support to `JalaliDate` for parsing date strings.
+
 ## [5.2.1](https://github.com/majiidd/persiantools/compare/5.2.0...5.2.1) - 2025-06-06
 
 - Added a Support section to the README.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2025 Majid Hajiloo
+Copyright (c) 2016 Majid Hajiloo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/persiantools/__init__.py
+++ b/persiantools/__init__.py
@@ -7,7 +7,7 @@
 
 __title__ = "persiantools"
 __url__ = "https://github.com/majiidd/persiantools"
-__version__ = "5.2.1"
+__version__ = "5.3.0"
 __build__ = __version__
 __author__ = "Majid Hajiloo"
 __author_email__ = "majid.hajiloo@gmail.com"

--- a/persiantools/jdatetime.py
+++ b/persiantools/jdatetime.py
@@ -1719,7 +1719,7 @@ class JalaliDateTime(JalaliDate):
         look for the table under "strftime() and strptime() Format Codes" section.
         """
         directives_regex_pattern = {
-            "%Y": r"(?P<Y>\d\d\d\d)",
+            "%Y": r"(?P<Y>\d{4})",
             "%m": r"(?P<m>1[0-2]|0[1-9]|[1-9])",
             "%d": r"(?P<d>3[0-1]|[1-2]\d|0[1-9]|[1-9]| [1-9])",
             "%a": cls._seqToRE(weekday_names_abbr, "a"),
@@ -1732,7 +1732,12 @@ class JalaliDateTime(JalaliDate):
             "%M": r"(?P<M>[0-5]\d|\d)",
             "%S": r"(?P<S>6[0-1]|[0-5]\d|\d)",
             "%f": r"(?P<f>\d{1,6})",
-            "%z": r"(?P<z>[-+](?P<zH>[0-1]?[0-9]|2[0-3])(?P<zM>[0-5]?[0-9])(?P<zS>[0-5]?[0-9])?(\.(?P<zf>(\d{,6})))?)",
+            "%z": (
+                r"(?P<z>[-+](?P<zH>2[0-3]|[0-1]\d)"
+                r"(?:[:]?)(?P<zM>[0-5]\d)"
+                r"(?:[:]?(?P<zS>[0-5]\d))?"
+                r"(?:\.(?P<zf>\d{1,6}))?)"
+            ),
             "%Z": cls._seqToRE(pytz.all_timezones, "Z"),
         }
 
@@ -1746,8 +1751,9 @@ class JalaliDateTime(JalaliDate):
         )
 
         data_string_regex = utils.replace(fmt, directives_regex_pattern)
+        full_pattern = f"^{data_string_regex}$"
 
-        if re.match(data_string_regex, data_string, re.IGNORECASE):
+        if re.match(full_pattern, data_string, re.IGNORECASE):
             directives = re.search(data_string_regex, data_string, re.IGNORECASE).groupdict()
 
             if "Y" in directives.keys() and len(directives.get("Y")) < 4:

--- a/persiantools/jdatetime.py
+++ b/persiantools/jdatetime.py
@@ -633,11 +633,12 @@ class JalaliDate:
             raise ValueError(f"Invalid date separator: {dtstr[4]}")
 
         month = int(dtstr[5:7])
-
         if dtstr[7] != "-":
             raise ValueError("Invalid date separator")
 
         day = int(dtstr[8:10])
+
+        cls._check_date_fields(year, month, day, "en")
 
         return [year, month, day]
 
@@ -957,7 +958,7 @@ class JalaliDate:
             "%Y": r"(?P<Y>\d{4})",
             "%y": r"(?P<y>\d{2})",
             "%m": r"(?P<m>1[0-2]|0?[1-9])",
-            "%d": r"(?P<d>3[0-1]|[1-2]\d|0?[1-9])",
+            "%d": r"(?P<d>\d{1,2})",
             "%b": cls._seqToRE(month_names_abbr_list, "b"),
             "%B": cls._seqToRE(month_names_list, "B"),
             "%a": cls._seqToRE(weekday_names_abbr_list, "a"),
@@ -973,8 +974,9 @@ class JalaliDate:
         )
 
         data_string_regex = utils.replace(fmt, directives_regex_pattern)
+        full_pattern = f"^{data_string_regex}$"
 
-        match = re.match(data_string_regex, data_string, re.IGNORECASE)
+        match = re.match(full_pattern, data_string, re.IGNORECASE)
         if not match:
             match_strict = re.match(f"^{data_string_regex}$", data_string, re.IGNORECASE)
             if not match_strict:
@@ -1005,9 +1007,6 @@ class JalaliDate:
             # values like 71, 72 .. 99 => 13xx.
         elif year is None:
             raise ValueError("Year information is missing from the date string or format.")
-
-        if "Y" in parsed_components and len(str(parsed_components["Y"])) != 4:
-            raise ValueError("Year specified with %Y must be a 4-digit number.")
 
         month = parsed_components.get("m")
         if month is None:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     long_description_content_type="text/markdown",
     classifiers=[
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
         "Natural Language :: Persian",
         "Operating System :: OS Independent",
         "Programming Language :: Python",

--- a/tests/test_digits.py
+++ b/tests/test_digits.py
@@ -90,3 +90,14 @@ class TestDigits(TestCase):
 
         with pytest.raises(TypeError):
             digits.to_word("123")
+
+    def test_fractional_part_too_long(self):
+        old_mantissa = digits.MANTISSA
+        try:
+            digits.MANTISSA = ("دهم",)
+            with self.assertRaises(ValueError, msg="Fractional part is too long"):
+                # 0.15 -> left = "0", right = "15", right.rstrip("0") == "15"
+                # mantissa_index = len("15") - 1 == 1, which is >= len(MANTISSA) == 1.
+                digits.to_word(0.15)
+        finally:
+            digits.MANTISSA = old_mantissa

--- a/tests/test_jalalidate.py
+++ b/tests/test_jalalidate.py
@@ -220,6 +220,11 @@ class TestJalaliDate(TestCase):
         with pytest.raises(ValueError, match="locale must be 'en' or 'fa'"):
             jdate.replace(locale="de")
 
+        with pytest.raises(ValueError):
+            JalaliDate.days_before_month(0)
+        with pytest.raises(ValueError):
+            JalaliDate.days_before_month(13)
+
     def test_leap(self):
         cases = [
             # First 33-year cycle
@@ -575,6 +580,7 @@ class TestJalaliDate(TestCase):
         self.assertEqual(JalaliDate.strptime("1367/02/14", "%Y/%m/%d"), JalaliDate(1367, 2, 14))
         self.assertEqual(JalaliDate.strptime("13670214", "%Y%m%d"), JalaliDate(1367, 2, 14))
         self.assertEqual(JalaliDate.strptime("16/03/1404", "%d/%m/%Y"), JalaliDate(1404, 3, 16))
+        self.assertEqual(JalaliDate.strptime("16/03/1404", "%d/%m/%Y", locale="en"), JalaliDate(1404, 3, 16))
 
         # 2. Year variations
         self.assertEqual(JalaliDate.strptime("99-01-01", "%y-%m-%d"), JalaliDate(1399, 1, 1))  # 99 > 70 => 1399
@@ -682,6 +688,8 @@ class TestJalaliDate(TestCase):
             JalaliDate.strptime("1402-12-30", "%Y-%m-%d")
         with self.assertRaises(ValueError):
             JalaliDate.strptime("98-12-30", "%y-%m-%d")
+        with self.assertRaises(ValueError):
+            JalaliDate.strptime("1404-01-01", "%Y-%m-%d", "ar")
 
         # 9. Edge cases
         # Leap year: 1399 was a leap year (Esfand has 30 days)

--- a/tests/test_jalalidate.py
+++ b/tests/test_jalalidate.py
@@ -225,8 +225,15 @@ class TestJalaliDate(TestCase):
 
         with pytest.raises(ValueError):
             JalaliDate.days_before_month(0)
+
         with pytest.raises(ValueError):
             JalaliDate.days_before_month(13)
+
+        with pytest.raises(ValueError):
+            JalaliDate.days_in_month(13, 1404)
+
+        with pytest.raises(ValueError):
+            JalaliDate.days_in_month(0, 1400)
 
     def test_leap(self):
         cases = [

--- a/tests/test_jalalidate.py
+++ b/tests/test_jalalidate.py
@@ -13,6 +13,7 @@ class TestJalaliDate(TestCase):
     def test_shamsi_to_gregorian(self):
         cases = [
             (JalaliDate(1100, 1, 1), date(1721, 3, 21)),
+            (JalaliDate(1210, 12, 30), date(1832, 3, 20)),
             (JalaliDate(1367, 2, 14), date(1988, 5, 4)),
             (JalaliDate(1395, 3, 21), date(2016, 6, 10)),
             (JalaliDate(1395, 12, 9), date(2017, 2, 27)),
@@ -67,6 +68,7 @@ class TestJalaliDate(TestCase):
             (JalaliDate(1402, 1, 1), date(2023, 3, 21)),
             (JalaliDate(1403, 1, 1), date(2024, 3, 20)),
             (JalaliDate(1404, 1, 1), date(2025, 3, 21)),
+            (JalaliDate(1498, 12, 30), date(2120, 3, 20)),
             (JalaliDate(1505, 1, 1), date(2126, 3, 21)),
             (JalaliDate.today(), date.today()),
         ]
@@ -124,6 +126,9 @@ class TestJalaliDate(TestCase):
 
     def test_checkdate(self):
         cases = [
+            (1206, 12, 30, False),
+            (1210, 12, 30, True),
+            (1214, 12, 30, True),
             (1367, 2, 14, True),
             (1395, 12, 30, True),
             (1394, 12, 30, False),
@@ -141,6 +146,9 @@ class TestJalaliDate(TestCase):
             (1400, 12, 30, False),
             (1403, 4, 3, True),
             (1403, 12, 30, True),
+            (1473, 12, 30, False),
+            (1474, 12, 30, True),
+            (1498, 12, 30, True),
         ]
         for year, month, day, valid in cases:
             self.assertEqual(JalaliDate.check_date(year, month, day), valid)

--- a/tests/test_jalalidate.py
+++ b/tests/test_jalalidate.py
@@ -136,6 +136,7 @@ class TestJalaliDate(TestCase):
             (1396, 7, 27, True),
             (1397, 11, 29, True),
             (1399, 11, 31, False),
+            (1400, 1, 32, False),
             (1400, 4, 25, True),
             (1400, 12, 30, False),
             (1403, 4, 3, True),
@@ -643,16 +644,16 @@ class TestJalaliDate(TestCase):
         )
 
         # 8. Invalid inputs
-        with self.assertRaises(ValueError, msg="Month out of range"):  # Invalid month number
+        with self.assertRaises(ValueError, msg="Month out of range"):
             JalaliDate.strptime("1400-13-01", "%Y-%m-%d")
-        # with self.assertRaises(ValueError, msg="Day out of range for month"): # Invalid day number
-        #     JalaliDate.strptime("1400-01-32", "%Y-%m-%d")
+        with self.assertRaises(ValueError, msg="Day out of range for month"):
+            JalaliDate.strptime("1400-01-32", "%Y-%m-%d")
         with self.assertRaises(ValueError, msg="Day out of range for month (Mehr has 30 days)"):
             JalaliDate.strptime("1400-07-31", "%Y-%m-%d")
         with self.assertRaises(ValueError, msg="Invalid month name"):
             JalaliDate.strptime("1399/Feb/20", "%Y/%b/%d")
-        # with self.assertRaises(ValueError, msg="String does not match format"):
-        #     JalaliDate.strptime("1400/01/01 Extra", "%Y/%m/%d")
+        with self.assertRaises(ValueError, msg="String does not match format"):
+            JalaliDate.strptime("1400/01/01 Extra", "%Y/%m/%d")
         with self.assertRaises(ValueError, msg="String does not match format - incorrect separator"):
             JalaliDate.strptime("1400.01.01", "%Y-%m-%d")
         with self.assertRaises(ValueError, msg="Year with %Y must be 4 digits"):
@@ -661,9 +662,7 @@ class TestJalaliDate(TestCase):
             JalaliDate.strptime("1-01-01", "%y-%m-%d")
         with self.assertRaises(ValueError, msg="Date string does not match format (empty date string)"):
             JalaliDate.strptime("", "%Y-%m-%d")
-        with self.assertRaises(
-            ValueError, msg="Date string does not match format (empty format string)"
-        ):  # This might lead to unexpected regex
+        with self.assertRaises(ValueError, msg="Date string does not match format (empty format string)"):
             JalaliDate.strptime("1400-01-01", "")
         with self.assertRaises(ValueError, msg="Month information missing"):
             JalaliDate.strptime("1400--01", "%Y-%m-%d")
@@ -671,9 +670,9 @@ class TestJalaliDate(TestCase):
             JalaliDate.strptime("1400-01-", "%Y-%m-%d")
         with self.assertRaises(ValueError, msg="Year information missing"):
             JalaliDate.strptime("-01-01", "%Y-%m-%d")
-        with self.assertRaises(ValueError):  # Esfand 30 for non-leap year 1402
+        with self.assertRaises(ValueError):
             JalaliDate.strptime("1402-12-30", "%Y-%m-%d")
-        with self.assertRaises(ValueError):  # Esfand 30 for non-leap year 1398
+        with self.assertRaises(ValueError):
             JalaliDate.strptime("98-12-30", "%y-%m-%d")
 
         # 9. Edge cases
@@ -688,8 +687,8 @@ class TestJalaliDate(TestCase):
         self.assertEqual(JalaliDate.strptime("1403-12-30", "%Y-%m-%d"), JalaliDate(1403, 12, 30))
         self.assertEqual(JalaliDate.strptime("03-12-30", "%y-%m-%d"), JalaliDate(1403, 12, 30))
 
-        # self.assertEqual(JalaliDate.strptime(f"{MINYEAR}-01-01", "%Y-%m-%d"), JalaliDate(MINYEAR, 1, 1))
-        # self.assertEqual(JalaliDate.strptime(f"{MAXYEAR}-12-29", "%Y-%m-%d"), JalaliDate(MAXYEAR, 12, 29))
+        self.assertEqual(JalaliDate.strptime(f"{MINYEAR:04d}-01-01", "%Y-%m-%d"), JalaliDate(MINYEAR, 1, 1))
+        self.assertEqual(JalaliDate.strptime(f"{MAXYEAR:04d}-12-29", "%Y-%m-%d"), JalaliDate(MAXYEAR, 12, 29))
 
         # Test %x and %c replacements
         # %x: %Y/%m/%d

--- a/tests/test_jalalidate.py
+++ b/tests/test_jalalidate.py
@@ -153,6 +153,9 @@ class TestJalaliDate(TestCase):
         for year, month, day, valid in cases:
             self.assertEqual(JalaliDate.check_date(year, month, day), valid)
 
+        with pytest.raises(ValueError):
+            JalaliDate._check_date_fields(1404, 3, 16, "ar")
+
     def test_completeday(self):
         jdate = JalaliDate(1398, 3, 17)
         self.assertEqual(jdate.year, 1398)
@@ -422,6 +425,24 @@ class TestJalaliDate(TestCase):
 
         with pytest.raises(ValueError):
             JalaliDate.fromisoformat("2021W123")
+
+        with pytest.raises(ValueError):
+            JalaliDate.fromisoformat("1395-03")
+
+        with pytest.raises(ValueError):
+            JalaliDate.fromisoformat("13950301")
+
+        with pytest.raises(ValueError):
+            JalaliDate.fromisoformat("1395-13-01")
+
+        with pytest.raises(ValueError):
+            JalaliDate.fromisoformat("1400-01-32")
+
+        with pytest.raises(ValueError):
+            JalaliDate.fromisoformat("1395-03-01 extra")
+
+        with pytest.raises(ValueError):
+            JalaliDate.fromisoformat(" 1395-03-01")
 
         j_date = JalaliDate(1400, 1, 1)
         self.assertEqual(j_date.strftime("%A, %d %B %Y"), "Yekshanbeh, 01 Farvardin 1400")

--- a/tests/test_jalalidatetime.py
+++ b/tests/test_jalalidatetime.py
@@ -103,10 +103,10 @@ class TestJalaliDateTime(TestCase):
         with pytest.raises(AssertionError):
             JalaliDateTime.check_utc_offset("invalid", timedelta(minutes=30))
 
-        with pytest.raises(TypeError) as excinfo:
+        with pytest.raises(TypeError):
             JalaliDateTime.check_utc_offset("utcoffset", 30)
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError):
             JalaliDateTime.check_utc_offset("dst", timedelta(seconds=61))
 
     def test_others(self):

--- a/tests/test_jalalidatetime.py
+++ b/tests/test_jalalidatetime.py
@@ -728,7 +728,7 @@ class TestJalaliDateTime(TestCase):
     def test_fromisoformat_invalid_string(self):
         with self.assertRaises(ValueError):
             JalaliDateTime.fromisoformat("invalid-date-time")
-        
+
         self.assertEqual(JalaliDateTime._find_isoformat_datetime_separator("2021W12"), 7)
 
         with pytest.raises(ValueError, match="Invalid ISO string"):

--- a/tests/test_jalalidatetime.py
+++ b/tests/test_jalalidatetime.py
@@ -365,7 +365,7 @@ class TestJalaliDateTime(TestCase):
             ("+0330", 3, 30),
             ("-0500", -5, 0),
             ("+0430", 4, 30),
-            # ("-0715", -7, 15),
+            ("-0715", -7, -15),
             ("+0000", 0, 0),
             ("-0000", 0, 0),
             ("+1400", 14, 0),
@@ -385,48 +385,44 @@ class TestJalaliDateTime(TestCase):
                 self.assertEqual(jdt.year, 1400)
                 self.assertEqual(jdt.hour, 10)
 
-    # def test_strptime_z_directive_invalid_formats(self):
-    #     base_dt_str = "1400-01-01 10:00:00"
-    #     fmt_base = "%Y-%m-%d %H:%M:%S"
+    def test_strptime_z_directive_invalid_formats(self):
+        base_dt_str = "1400-01-01 10:00:00"
+        fmt_base = "%Y-%m-%d %H:%M:%S"
 
-    #     invalid_z_formats = [
-    #         "0330",       # Missing sign
-    #         "+330",       # Incorrect number of digits (hour)
-    #         "+033",       # Incorrect number of digits (minute)
-    #         "+03:3",      # Incorrect number of digits (minute with colon)
-    #         "+03-30",     # Invalid separator
-    #         "03:30",      # Missing sign with colon
-    #         "+03:300",    # Too many minute digits
-    #         "+030:30",    # Too many hour digits
-    #         "+0A30",      # Non-numeric hour
-    #         "+03B0",      # Non-numeric minute
-    #         "+2500",      # Hour out of range (max is +2359 or +1400 for this specific regex in Python for %z) - Python's %z parse is up to +HHMM or -HHMM
-    #         # Python's strptime %z doesn't seem to strictly enforce +14 / -14 for hours.
-    #         # The regex (?P<z>[-+](?P<zH>[0-1]?[0-9]|2[0-3])(?P<zM>[0-5]?[0-9])
-    #         # in persiantools.jdatetime for %z limits zH to 23.
-    #         # Let's test against that.
-    #         "+2400",      # Hour part out of range (>=24)
-    #         "-2400",
-    #         "+0360",      # Minute part out of range (>=60)
-    #         "-0360",
-    #         "+03:60",
-    #         " +0330",     # Leading space before offset
-    #         "+0330 ",     # Trailing space after offset (will cause full string match failure)
-    #         "GMT+0330",   # Non-standard prefix
-    #     ]
+        invalid_z_formats = [
+            "0330",  # Missing sign: In Python, the %z directive requires a leading '+' or '-' for the timezone offset.
+            "+330",  # Incorrect number of digits (hour)
+            "+033",  # Incorrect number of digits (minute)
+            "+03:3",  # Incorrect number of digits (minute with colon)
+            "+03-30",  # Invalid separator
+            "03:30",  # Missing sign with colon
+            "+03:300",  # Too many minute digits
+            "+030:30",  # Too many hour digits
+            "+0A30",  # Non-numeric hour
+            "+03B0",  # Non-numeric minute
+            "+2500",  # Hour out of range (max is +2359 or +1400 for this specific regex in Python for %z)
+            "+2400",  # Hour part out of range (>=24)
+            "-2400",
+            "+0360",  # Minute part out of range (>=60)
+            "-0360",
+            "+03:60",
+            " +0330",  # Leading space before offset
+            "+0330 ",  # Trailing space after offset (will cause full string match failure)
+            "GMT+0330",  # Non-standard prefix
+        ]
 
-    #     for tz_str in invalid_z_formats:
-    #         date_string = f"{base_dt_str} {tz_str}"
-    #         fmt = f"{fmt_base} %z"
-    #         with self.subTest(date_string=date_string, fmt=fmt):
-    #             with self.assertRaises(ValueError, msg=f"Failed for invalid tz string: {tz_str}"):
-    #                 JalaliDateTime.strptime(date_string, fmt)
+        for tz_str in invalid_z_formats:
+            date_string = f"{base_dt_str} {tz_str}"
+            fmt = f"{fmt_base} %z"
+            with self.subTest(date_string=date_string, fmt=fmt):
+                with self.assertRaises(ValueError, msg=f"Failed for invalid tz string: {tz_str}"):
+                    JalaliDateTime.strptime(date_string, fmt)
 
-    #     # Test %z without enough characters following
-    #     with self.assertRaises(ValueError):
-    #         JalaliDateTime.strptime(f"{base_dt_str} +", f"{fmt_base} %z")
-    #     with self.assertRaises(ValueError):
-    #         JalaliDateTime.strptime(f"{base_dt_str} +03", f"{fmt_base} %z")
+        # Test %z without enough characters following
+        with self.assertRaises(ValueError):
+            JalaliDateTime.strptime(f"{base_dt_str} +", f"{fmt_base} %z")
+        with self.assertRaises(ValueError):
+            JalaliDateTime.strptime(f"{base_dt_str} +03", f"{fmt_base} %z")
 
     def test_strptime_z_directive_locale_independence(self):
         base_dt_str = "1400-01-01 10:00:00"

--- a/tests/test_jalalidatetime.py
+++ b/tests/test_jalalidatetime.py
@@ -329,6 +329,11 @@ class TestJalaliDateTime(TestCase):
         jdt = JalaliDateTime(1374, 4, 8, 16, 28, 3, 227, pytz.utc)
         self.assertEqual(jdt, JalaliDateTime.strptime(jdt.strftime("%c %f %z %Z"), "%c %f %z %Z"))
 
+        jdt_utc_combined = JalaliDateTime(1374, 4, 8, 16, 28, 3, 227, timezone.utc)
+        self.assertEqual(
+            jdt_utc_combined, JalaliDateTime.strptime(jdt_utc_combined.strftime("%c %f %z %Z"), "%c %f %z %Z")
+        )
+
     def test_strptime_basic(self):
         date_string = "1400-01-01 12:30:45"
         fmt = "%Y-%m-%d %H:%M:%S"
@@ -351,6 +356,102 @@ class TestJalaliDateTime(TestCase):
         self.assertEqual(jdt.minute, 30)
         self.assertEqual(jdt.second, 45)
         self.assertEqual(jdt.utcoffset(), timedelta(hours=3, minutes=30))
+
+    def test_strptime_z_directive_valid_formats(self):
+        base_dt_str = "1400-01-01 10:00:00"
+        fmt_base = "%Y-%m-%d %H:%M:%S"
+
+        valid_z_formats = [
+            ("+0330", 3, 30),
+            ("-0500", -5, 0),
+            ("+0430", 4, 30),
+            # ("-0715", -7, 15),
+            ("+0000", 0, 0),
+            ("-0000", 0, 0),
+            ("+1400", 14, 0),
+            ("-1400", -14, 0),
+            ("+0059", 0, 59),
+        ]
+
+        for tz_str, hours, minutes in valid_z_formats:
+            date_string = f"{base_dt_str} {tz_str}"
+            fmt = f"{fmt_base} %z"
+            with self.subTest(date_string=date_string, fmt=fmt):
+                jdt = JalaliDateTime.strptime(date_string, fmt)
+                self.assertIsNotNone(jdt.tzinfo, f"tzinfo should not be None for {date_string}")
+                self.assertIsInstance(jdt.tzinfo, timezone, f"tzinfo should be datetime.timezone for {date_string}")
+                expected_offset = timedelta(hours=hours, minutes=minutes)
+                self.assertEqual(jdt.utcoffset(), expected_offset, f"Offset mismatch for {date_string}")
+                self.assertEqual(jdt.year, 1400)
+                self.assertEqual(jdt.hour, 10)
+
+    # def test_strptime_z_directive_invalid_formats(self):
+    #     base_dt_str = "1400-01-01 10:00:00"
+    #     fmt_base = "%Y-%m-%d %H:%M:%S"
+
+    #     invalid_z_formats = [
+    #         "0330",       # Missing sign
+    #         "+330",       # Incorrect number of digits (hour)
+    #         "+033",       # Incorrect number of digits (minute)
+    #         "+03:3",      # Incorrect number of digits (minute with colon)
+    #         "+03-30",     # Invalid separator
+    #         "03:30",      # Missing sign with colon
+    #         "+03:300",    # Too many minute digits
+    #         "+030:30",    # Too many hour digits
+    #         "+0A30",      # Non-numeric hour
+    #         "+03B0",      # Non-numeric minute
+    #         "+2500",      # Hour out of range (max is +2359 or +1400 for this specific regex in Python for %z) - Python's %z parse is up to +HHMM or -HHMM
+    #         # Python's strptime %z doesn't seem to strictly enforce +14 / -14 for hours.
+    #         # The regex (?P<z>[-+](?P<zH>[0-1]?[0-9]|2[0-3])(?P<zM>[0-5]?[0-9])
+    #         # in persiantools.jdatetime for %z limits zH to 23.
+    #         # Let's test against that.
+    #         "+2400",      # Hour part out of range (>=24)
+    #         "-2400",
+    #         "+0360",      # Minute part out of range (>=60)
+    #         "-0360",
+    #         "+03:60",
+    #         " +0330",     # Leading space before offset
+    #         "+0330 ",     # Trailing space after offset (will cause full string match failure)
+    #         "GMT+0330",   # Non-standard prefix
+    #     ]
+
+    #     for tz_str in invalid_z_formats:
+    #         date_string = f"{base_dt_str} {tz_str}"
+    #         fmt = f"{fmt_base} %z"
+    #         with self.subTest(date_string=date_string, fmt=fmt):
+    #             with self.assertRaises(ValueError, msg=f"Failed for invalid tz string: {tz_str}"):
+    #                 JalaliDateTime.strptime(date_string, fmt)
+
+    #     # Test %z without enough characters following
+    #     with self.assertRaises(ValueError):
+    #         JalaliDateTime.strptime(f"{base_dt_str} +", f"{fmt_base} %z")
+    #     with self.assertRaises(ValueError):
+    #         JalaliDateTime.strptime(f"{base_dt_str} +03", f"{fmt_base} %z")
+
+    def test_strptime_z_directive_locale_independence(self):
+        base_dt_str = "1400-01-01 10:00:00"
+        tz_str = "+0545"
+        fmt = "%Y-%m-%d %H:%M:%S %z"
+        date_string = f"{base_dt_str} {tz_str}"
+        expected_offset = timedelta(hours=5, minutes=45)
+
+        # Test with locale 'en'
+        jdt_en = JalaliDateTime.strptime(date_string, fmt, locale="en")
+        self.assertIsNotNone(jdt_en.tzinfo)
+        self.assertEqual(jdt_en.utcoffset(), expected_offset)
+        self.assertEqual(jdt_en.year, 1400)
+
+        # Test with locale 'fa'
+        jdt_fa = JalaliDateTime.strptime(date_string, fmt, locale="fa")
+        self.assertIsNotNone(jdt_fa.tzinfo)
+        self.assertEqual(jdt_fa.utcoffset(), expected_offset)
+        self.assertEqual(jdt_fa.year, 1400)
+
+        date_string_fa_main = f"۱۴۰۰-۰۱-۰۱ ۱۰:۰۰:۰۰ {tz_str}"
+        jdt_fa_main = JalaliDateTime.strptime(date_string_fa_main, fmt, locale="fa")
+        self.assertIsNotNone(jdt_fa_main.tzinfo)
+        self.assertEqual(jdt_fa_main.utcoffset(), expected_offset)
+        self.assertEqual(jdt_fa_main.year, 1400)
 
     def test_strptime_with_locale_fa(self):
         date_string = "۱۴۰۰-۰۱-۰۱ ۱۲:۳۰:۴۵"
@@ -637,3 +738,66 @@ class TestJalaliDateTime(TestCase):
         iso_format = original.isoformat()
         parsed = JalaliDateTime.fromisoformat(iso_format)
         self.assertEqual(original, parsed)
+
+    def test_isoformat_timezone_representation(self):
+        # 1. UTC Timezone
+        jdt_utc = JalaliDateTime(1400, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(jdt_utc.isoformat(), "1400-01-01T12:00:00+00:00")
+
+        # 2. Positive Offset Timezones
+        tz_plus_3_30 = timezone(timedelta(hours=3, minutes=30))
+        jdt_plus_3_30 = JalaliDateTime(1401, 2, 15, 10, 30, 0, tzinfo=tz_plus_3_30)
+        self.assertEqual(jdt_plus_3_30.isoformat(), "1401-02-15T10:30:00+03:30")
+
+        tz_plus_5 = timezone(timedelta(hours=5))
+        jdt_plus_5 = JalaliDateTime(1402, 3, 20, 8, 0, 0, tzinfo=tz_plus_5)
+        self.assertEqual(jdt_plus_5.isoformat(), "1402-03-20T08:00:00+05:00")
+
+        # 3. Negative Offset Timezones
+        tz_minus_4_45 = timezone(timedelta(hours=-4, minutes=-45))
+        jdt_minus_4_45 = JalaliDateTime(1403, 4, 10, 16, 15, 0, tzinfo=tz_minus_4_45)
+        self.assertEqual(jdt_minus_4_45.isoformat(), "1403-04-10T16:15:00-04:45")
+
+        tz_minus_4_45 = timezone(timedelta(hours=-4, minutes=45))
+        jdt_minus_4_45 = JalaliDateTime(1403, 4, 10, 16, 15, 0, tzinfo=tz_minus_4_45)
+        self.assertEqual(jdt_minus_4_45.isoformat(), "1403-04-10T16:15:00-03:15")
+
+        tz_direct_minus_4_45 = timezone(timedelta(seconds=-(4 * 3600 + 45 * 60)))
+        jdt_direct_minus_4_45 = JalaliDateTime(1403, 4, 10, 16, 15, 0, tzinfo=tz_direct_minus_4_45)
+        self.assertEqual(jdt_direct_minus_4_45.isoformat(), "1403-04-10T16:15:00-04:45")
+
+        tz_minus_8 = timezone(timedelta(hours=-8))
+        jdt_minus_8 = JalaliDateTime(1399, 12, 29, 23, 30, 59, tzinfo=tz_minus_8)
+        self.assertEqual(jdt_minus_8.isoformat(), "1399-12-29T23:30:59-08:00")
+
+        # 4. Offsets with zero minutes (covered by +05:00 and -08:00 above)
+        self.assertEqual(
+            JalaliDateTime(1402, 3, 20, 8, 0, 0, tzinfo=timezone(timedelta(hours=5))).isoformat(),
+            "1402-03-20T08:00:00+05:00",
+        )
+
+        # 5. Microseconds with timezone offset
+        jdt_utc_ms = JalaliDateTime(1400, 1, 1, 12, 30, 45, 123456, tzinfo=timezone.utc)
+        self.assertEqual(jdt_utc_ms.isoformat(), "1400-01-01T12:30:45.123456+00:00")
+
+        jdt_offset_ms = JalaliDateTime(1400, 6, 10, 10, 20, 30, 654321, tzinfo=tz_plus_3_30)
+        self.assertEqual(jdt_offset_ms.isoformat(), "1400-06-10T10:20:30.654321+03:30")
+
+        # 6. Default Separator 'T' (implicitly tested in all above cases)
+        self.assertIn("T", jdt_utc.isoformat())
+
+        # 7. Custom Separator
+        jdt_custom_sep = JalaliDateTime(1400, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(jdt_custom_sep.isoformat(sep=" "), "1400-01-01 12:00:00+00:00")
+
+        jdt_custom_sep_offset = JalaliDateTime(1401, 5, 5, 10, 10, 10, tzinfo=tz_minus_8)
+        self.assertEqual(jdt_custom_sep_offset.isoformat(sep="_"), "1401-05-05_10:10:10-08:00")
+
+        # 8. Naive JalaliDateTime (no offset string)
+        jdt_naive = JalaliDateTime(1398, 10, 5, 12, 30, 0)
+        self.assertEqual(jdt_naive.isoformat(), "1398-10-05T12:30:00")
+        # With microseconds
+        jdt_naive_ms = JalaliDateTime(1398, 10, 5, 12, 30, 0, 123)
+        self.assertEqual(jdt_naive_ms.isoformat(), "1398-10-05T12:30:00.000123")
+        # With custom separator
+        self.assertEqual(jdt_naive.isoformat(sep=" "), "1398-10-05 12:30:00")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for parsing date strings using the `strptime` method in Jalali date and datetime classes, including support for English and Persian locales, month and weekday names, and timezone offsets.

- **Bug Fixes**
  - Improved validation for date parsing, error handling for invalid inputs, and enhanced ISO format parsing for edge cases.

- **Documentation**
  - Updated the changelog with details for version 5.3.0.

- **Chores**
  - Updated version number and license information.
  - Adjusted setup configuration for license classifier.

- **Tests**
  - Added comprehensive tests for date and datetime parsing, timezone handling, and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->