### PR TITLE
Removed `pytz` dependency;

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,19 +4,33 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
-indent_size = 4
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-end_of_line = lf
+indent_style = space
+indent_size = 4
 
+# Python: Black uses 4 spaces; max line length here is informational for editors.
 [*.py]
+indent_style = space
+indent_size = 4
 max_line_length = 120
-quote_type = double
 
-[*.{yml,yaml}]
+# Config/data files commonly use 2-space indentation.
+[*.{yml,yaml,toml,json}]
+indent_style = space
 indent_size = 2
 
-[*.md]
+# Markdown / reStructuredText: keep trailing spaces (for hard line breaks) and allow missing final newline.
+[*.{md,rst,mdx}]
 insert_final_newline = false
 trim_trailing_whitespace = false
+
+# Makefile must use tabs.
+[Makefile]
+indent_style = tab
+
+# Shell scripts: LF endings, ensure final newline.
+[*.sh]
+end_of_line = lf
+insert_final_newline = true

--- a/.flake8
+++ b/.flake8
@@ -1,19 +1,33 @@
+
 [flake8]
+# Keep flake8 compatible with Black:
+# - E203 and W503 conflict with Black's formatting choices.
+# - E501 (line length) is managed by Black; we still set max-line-length for plugins that read it.
 max-line-length = 120
 extend-ignore =
     E203,
     E501,
     W503,
     C901,
-max-complexity = 10
+# Core error families:
 select = B,C,E,F,W
+
+# Common junk folders we don't want to lint
 exclude =
     .git,
     __pycache__,
+    .tox,
+    .mypy_cache,
+    .pytest_cache,
     build,
     dist,
     migrations,
     venv,
     .venv,
     .eggs,
-    *.egg
+    *.egg,
+    docs/_build
+
+# Tolerate unused imports in package initializers and allow test module oddities
+per-file-ignores =
+    __init__.py:F401

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,41 @@
-* text=auto eol=lf
-*.bat text eol=crlf
+# Normalize text files to LF in repo and working tree (cross‑platform friendly)
+*          text=auto eol=lf
+
+# Windows batch scripts should use CRLF
+*.bat      text eol=crlf
+
+# Common source / config files: keep LF explicitly
+*.py       text eol=lf
+*.pyi      text eol=lf
+*.sh       text eol=lf
+Makefile   text eol=lf
+*.toml     text eol=lf
+*.ini      text eol=lf
+*.cfg      text eol=lf
+*.yml      text eol=lf
+*.yaml     text eol=lf
+*.json     text eol=lf
+*.md       text eol=lf
+*.rst      text eol=lf
+
+# Binary assets: never touch line endings or diff them
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.ico      binary
+*.pdf      binary
+*.zip      binary
+*.tar      binary
+*.gz       binary
+*.tgz      binary
+*.xz       binary
+*.bz2      binary
+*.whl      binary
+
+# Patch artifacts should not be normalized
+*.diff     -text
+*.patch    -text
+
+# Exclude CI meta from GitHub source archives (git archive), keep code clean
+/.github   export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,23 @@
 name: ci
 
-on: [push]
+on:
+  push:
+    branches: ["**"]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tests:
-    name: ${{matrix.os}} / ${{ matrix.python-version }}
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
@@ -21,9 +31,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Cache Pipenv virtualenv
+        id: cache-pipenv
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
 
       - name: Install pipenv
-        run: python -m pip install pipenv
+        run: python -m pip install --upgrade pip pipenv
 
       - name: Install dependencies
         shell: bash
@@ -31,12 +51,11 @@ jobs:
           PIPENV_NOSPIN: "1"
           PIPENV_VENV_IN_PROJECT: "1"
         run: |
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          if [ "${{ runner.os }}" = "Windows" ]; then
             export PIPENV_PYTHON="${pythonLocation}\\python.exe"
           else
             export PIPENV_PYTHON="${pythonLocation}/bin/python"
           fi
-
           pipenv install --dev
 
       - name: Display Python version
@@ -45,13 +64,22 @@ jobs:
           PIPENV_VENV_IN_PROJECT: "1"
         run: pipenv run python -V
 
-      - name: Run tests
+      - name: Run tests (with coverage on Linux CPython 3.12)
+        if: ${{ runner.os == 'Linux' && matrix.python-version == '3.12' }}
         env:
           PIPENV_NOSPIN: "1"
           PIPENV_VENV_IN_PROJECT: "1"
         run: pipenv run pytest -ra --cov=persiantools --cov-report xml:coverage.xml tests/
 
+      - name: Run tests (no coverage)
+        if: ${{ !(runner.os == 'Linux' && matrix.python-version == '3.12') }}
+        env:
+          PIPENV_NOSPIN: "1"
+          PIPENV_VENV_IN_PROJECT: "1"
+        run: pipenv run pytest -ra tests/
+
       - name: Upload coverage to Codecov
+        if: runner.os == 'Linux' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
@@ -67,40 +95,50 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
       - name: Install pre-commit
         run: pip install pre-commit
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: pre-commit run --all-files
 
   build-and-publish:
-    if: github.repository == 'majiidd/persiantools' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.repository == 'majiidd/persiantools' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.12
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
 
-    - name: Install pypa/build
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade build setuptools
-        python -m build --sdist --wheel --outdir dist/ .
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+          python -m build --sdist --wheel --outdir dist/ .
 
-    - name: Publish to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository-url: https://test.pypi.org/legacy/
-        verbose: true
+      - name: Publish to Test PyPI
+        if: always()
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          verbose: true
 
-    - name: Publish to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        verbose: true
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,24 @@ dmypy.json
 
 # Coverage
 cover/
+
+# Ruff linter cache
+.ruff_cache/
+
+# pytype
+.pytype/
+
+# pytest-benchmark
+.benchmarks/
+
+# PEP 582 local packages
+__pypackages__/
+
+# Swap / temp files
+*~
+*.swp
+*.swo
+
+# dotenv variants (keep example)
+.env.*
+!.env.example

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: ["--py39-plus"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
         args: [ '--maxkb=256' ]
@@ -27,19 +27,19 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black
         types_or: [ python, pyi ]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.2.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         additional_dependencies: [ flake8-bugbear, flake8-implicit-str-concat ]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.3
+    rev: 1.8.6
     hooks:
       - id: bandit
         args: ["--skip", "B101,B403"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,17 @@ repos:
         args: [ '--fix=lf' ]
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-xml
+      - id: detect-private-key
+      - id: check-shebang-scripts-are-executable
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1
     hooks:
       - id: isort
+        args: ["--profile", "black"]
 
   - repo: https://github.com/psf/black
     rev: 25.9.0
@@ -43,3 +49,14 @@ repos:
     hooks:
       - id: bandit
         args: ["--skip", "B101,B403"]
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: python-no-eval
+      - id: python-check-blanket-noqa
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.18.2
+    hooks:
+      - id: mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-
 # Changelog
+
+## [5.4.0](https://github.com/majiidd/persiantools/compare/5.3.0...5.4.0) - 2025-09-26
+
+- Removed `pytz` dependency; migrated fully to `zoneinfo` and `datetime.timezone`.
+- Updated `JalaliDateTime` implementation and fixed timezone handling.
+- Refined CI/CD workflows and linting configuration.
 
 ## [5.3.0](https://github.com/majiidd/persiantools/compare/5.2.1...5.3.0) - 2025-06-06
 

--- a/Pipfile
+++ b/Pipfile
@@ -4,16 +4,13 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pytz = "==2025.2"
 
 [dev-packages]
-coverage = "==7.8.2"
-pytest = "==8.4.0"
-pytest-cov = "==6.1.1"
-pre-commit = "==4.2.0"
-tomli = "==2.2.1"
+coverage = ">=7.10.0,<8.0.0"
+pytest = ">=8.4.0,<9.0.0"
+pytest-cov = ">=7.0.0,<8.0.0"
+pre-commit = ">=4.3.0,<5.0.0"
+tomli = ">=2.2.1,<3.0.0"
 exceptiongroup = {version = "1.3.0", python_versions = "<3.11"}
 atomicwrites = {version = "1.4.1", sys_platform = "== 'win32'"}
-
-[requires]
-python_version = "3"
+tzdata = {version = "*", markers = "platform_system == 'Windows'"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "36be3e840ae56747c54e4ee17aba156116ecbf2ba906dd6b0ad89cd70cebcc46"
+            "sha256": "4ecd239e6c64280318c8e8280c97bf5e0c8b7249577aa3b58ee88b81d915f98a"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -15,16 +13,7 @@
             }
         ]
     },
-    "default": {
-        "pytz": {
-            "hashes": [
-                "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3",
-                "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"
-            ],
-            "index": "pypi",
-            "version": "==2025.2"
-        }
-    },
+    "default": {},
     "develop": {
         "atomicwrites": {
             "hashes": [
@@ -46,84 +35,121 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:00f2e2f2e37f47e5f54423aeefd6c32a7dbcedc033fcd3928a4f4948e8b96af7",
-                "sha256:05364b9cc82f138cc86128dc4e2e1251c2981a2218bfcd556fe6b0fbaa3501be",
-                "sha256:0774df1e093acb6c9e4d58bce7f86656aeed6c132a16e2337692c12786b32404",
-                "sha256:07a989c867986c2a75f158f03fdb413128aad29aca9d4dbce5fc755672d96f11",
-                "sha256:0bdc8bf760459a4a4187b452213e04d039990211f98644c7292adf1e471162b5",
-                "sha256:0e49824808d4375ede9dd84e9961a59c47f9113039f1a525e6be170aa4f5c34d",
-                "sha256:145b07bea229821d51811bf15eeab346c236d523838eda395ea969d120d13347",
-                "sha256:159b81df53a5fcbc7d45dae3adad554fdbde9829a994e15227b3f9d816d00b36",
-                "sha256:1676628065a498943bd3f64f099bb573e08cf1bc6088bbe33cf4424e0876f4b3",
-                "sha256:1aec326ed237e5880bfe69ad41616d333712c7937bcefc1343145e972938f9b3",
-                "sha256:1e1448bb72b387755e1ff3ef1268a06617afd94188164960dba8d0245a46004b",
-                "sha256:1efa4166ba75ccefd647f2d78b64f53f14fb82622bc94c5a5cb0a622f50f1c9e",
-                "sha256:26a4636ddb666971345541b59899e969f3b301143dd86b0ddbb570bd591f1e85",
-                "sha256:2bd0a0a5054be160777a7920b731a0570284db5142abaaf81bcbb282b8d99279",
-                "sha256:2c08b05ee8d7861e45dc5a2cc4195c8c66dca5ac613144eb6ebeaff2d502e73d",
-                "sha256:2db10dedeb619a771ef0e2949ccba7b75e33905de959c2643a4607bef2f3fb3a",
-                "sha256:2f9bc608fbafaee40eb60a9a53dbfb90f53cc66d3d32c2849dc27cf5638a21e3",
-                "sha256:34759ee2c65362163699cc917bdb2a54114dd06d19bab860725f94ef45a3d9b7",
-                "sha256:3da9b771c98977a13fbc3830f6caa85cae6c9c83911d24cb2d218e9394259c57",
-                "sha256:3f5673888d3676d0a745c3d0e16da338c5eea300cb1f4ada9c872981265e76d8",
-                "sha256:4000a31c34932e7e4fa0381a3d6deb43dc0c8f458e3e7ea6502e6238e10be625",
-                "sha256:43ff5033d657cd51f83015c3b7a443287250dc14e69910577c3e03bd2e06f27b",
-                "sha256:46d532db4e5ff3979ce47d18e2fe8ecad283eeb7367726da0e5ef88e4fe64740",
-                "sha256:496948261eaac5ac9cf43f5d0a9f6eb7a6d4cb3bedb2c5d294138142f5c18f2a",
-                "sha256:4c26c2396674816deaeae7ded0e2b42c26537280f8fe313335858ffff35019be",
-                "sha256:5040536cf9b13fb033f76bcb5e1e5cb3b57c4807fef37db9e0ed129c6a094257",
-                "sha256:546e537d9e24efc765c9c891328f30f826e3e4808e31f5d0f87c4ba12bbd1622",
-                "sha256:5e818796f71702d7a13e50c70de2a1924f729228580bcba1607cccf32eea46e6",
-                "sha256:5feb7f2c3e6ea94d3b877def0270dff0947b8d8c04cfa34a17be0a4dc1836879",
-                "sha256:641988828bc18a6368fe72355df5f1703e44411adbe49bba5644b941ce6f2e3a",
-                "sha256:670a13249b957bb9050fab12d86acef7bf8f6a879b9d1a883799276e0d4c674a",
-                "sha256:6782a12bf76fa61ad9350d5a6ef5f3f020b57f5e6305cbc663803f2ebd0f270a",
-                "sha256:684ca9f58119b8e26bef860db33524ae0365601492e86ba0b71d513f525e7050",
-                "sha256:6e6c86888fd076d9e0fe848af0a2142bf606044dc5ceee0aa9eddb56e26895a0",
-                "sha256:726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32",
-                "sha256:76090fab50610798cc05241bf83b603477c40ee87acd358b66196ab0ca44ffa1",
-                "sha256:8165584ddedb49204c4e18da083913bdf6a982bfb558632a79bdaadcdafd0d48",
-                "sha256:820157de3a589e992689ffcda8639fbabb313b323d26388d02e154164c57b07f",
-                "sha256:8369a7c8ef66bded2b6484053749ff220dbf83cba84f3398c84c51a6f748a008",
-                "sha256:86a323a275e9e44cdf228af9b71c5030861d4d2610886ab920d9945672a81223",
-                "sha256:876cbfd0b09ce09d81585d266c07a32657beb3eaec896f39484b631555be0fe2",
-                "sha256:8966a821e2083c74d88cca5b7dcccc0a3a888a596a04c0b9668a891de3a0cc53",
-                "sha256:8ab4a51cb39dc1933ba627e0875046d150e88478dbe22ce145a68393e9652975",
-                "sha256:8e1a26e7e50076e35f7afafde570ca2b4d7900a491174ca357d29dece5aacee7",
-                "sha256:94316e13f0981cbbba132c1f9f365cac1d26716aaac130866ca812006f662199",
-                "sha256:9a990f6510b3292686713bfef26d0049cd63b9c7bb17e0864f133cbfd2e6167f",
-                "sha256:9fe449ee461a3b0c7105690419d0b0aba1232f4ff6d120a9e241e58a556733f7",
-                "sha256:a886d531373a1f6ff9fad2a2ba4a045b68467b779ae729ee0b3b10ac20033b27",
-                "sha256:ab9b09a2349f58e73f8ebc06fac546dd623e23b063e5398343c5270072e3201c",
-                "sha256:b039ffddc99ad65d5078ef300e0c7eed08c270dc26570440e3ef18beb816c1ca",
-                "sha256:b069938961dfad881dc2f8d02b47645cd2f455d3809ba92a8a687bf513839787",
-                "sha256:b99058eef42e6a8dcd135afb068b3d53aff3921ce699e127602efff9956457a9",
-                "sha256:bd8ec21e1443fd7a447881332f7ce9d35b8fbd2849e761bb290b584535636b0a",
-                "sha256:bf8111cddd0f2b54d34e96613e7fbdd59a673f0cf5574b61134ae75b6f5a33b8",
-                "sha256:c9392773cffeb8d7e042a7b15b82a414011e9d2b5fdbbd3f7e6a6b17d5e21b20",
-                "sha256:cb86337a4fcdd0e598ff2caeb513ac604d2f3da6d53df2c8e368e07ee38e277d",
-                "sha256:da23ce9a3d356d0affe9c7036030b5c8f14556bd970c9b224f9c8205505e3b99",
-                "sha256:dc67994df9bcd7e0150a47ef41278b9e0a0ea187caba72414b71dc590b99a108",
-                "sha256:de77c3ba8bb686d1c411e78ee1b97e6e0b963fb98b1637658dd9ad2c875cf9d7",
-                "sha256:e2f6fe3654468d061942591aef56686131335b7a8325684eda85dacdf311356c",
-                "sha256:e6ea7dba4e92926b7b5f0990634b78ea02f208d04af520c73a7c876d5a8d36cb",
-                "sha256:e6fcbbd35a96192d042c691c9e0c49ef54bd7ed865846a3c9d624c30bb67ce46",
-                "sha256:ea561010914ec1c26ab4188aef8b1567272ef6de096312716f90e5baa79ef8ca",
-                "sha256:eacd2de0d30871eff893bab0b67840a96445edcb3c8fd915e6b11ac4b2f3fa6d",
-                "sha256:ec455eedf3ba0bbdf8f5a570012617eb305c63cb9f03428d39bf544cb2b94837",
-                "sha256:ef2f22795a7aca99fc3c84393a55a53dd18ab8c93fb431004e4d8f0774150f54",
-                "sha256:fd51355ab8a372d89fb0e6a31719e825cf8df8b6724bee942fb5b92c3f016ba3"
+                "sha256:03ffc58aacdf65d2a82bbeb1ffe4d01ead4017a21bfd0454983b88ca73af94b9",
+                "sha256:097c1591f5af4496226d5783d036bf6fd6cd0cbc132e071b33861de756efb880",
+                "sha256:0b944ee8459f515f28b851728ad224fa2d068f1513ef6b7ff1efafeb2185f999",
+                "sha256:0ebbaddb2c19b71912c6f2518e791aa8b9f054985a0769bdb3a53ebbc765c6a1",
+                "sha256:10b24412692df990dbc34f8fb1b6b13d236ace9dfdd68df5b28c2e39cafbba13",
+                "sha256:10b6ba00ab1132a0ce4428ff68cf50a25efd6840a42cdf4239c9b99aad83be8b",
+                "sha256:121da30abb574f6ce6ae09840dae322bef734480ceafe410117627aa54f76d82",
+                "sha256:18afb24843cbc175687225cab1138c95d262337f5473512010e46831aa0c2973",
+                "sha256:1b4fd784344d4e52647fd7857b2af5b3fbe6c239b0b5fa63e94eb67320770e0f",
+                "sha256:1ca6db7c8807fb9e755d0379ccc39017ce0a84dcd26d14b5a03b78563776f681",
+                "sha256:1ef2319dd15a0b009667301a3f84452a4dc6fddfd06b0c5c53ea472d3989fbf0",
+                "sha256:2120043f147bebb41c85b97ac45dd173595ff14f2a584f2963891cbcc3091541",
+                "sha256:212f8f2e0612778f09c55dd4872cb1f64a1f2b074393d139278ce902064d5b32",
+                "sha256:240af60539987ced2c399809bd34f7c78e8abe0736af91c3d7d0e795df633d17",
+                "sha256:2a78cd46550081a7909b3329e2266204d584866e8d97b898cd7fb5ac8d888b1a",
+                "sha256:2af88deffcc8a4d5974cf2d502251bc3b2db8461f0b66d80a449c33757aa9f40",
+                "sha256:2c8b9a0636f94c43cd3576811e05b89aa9bc2d0a85137affc544ae5cb0e4bfbd",
+                "sha256:2fafd773231dd0378fdba66d339f84904a8e57a262f583530f4f156ab83863e6",
+                "sha256:314f2c326ded3f4b09be11bc282eb2fc861184bc95748ae67b360ac962770be7",
+                "sha256:33a5e6396ab684cb43dc7befa386258acb2d7fae7f67330ebb85ba4ea27938eb",
+                "sha256:3445258bcded7d4aa630ab8296dea4d3f15a255588dd535f980c193ab6b95f3f",
+                "sha256:35f5e3f9e455bb17831876048355dca0f758b6df22f49258cb5a91da23ef437d",
+                "sha256:39508ffda4f343c35f3236fe8d1a6634a51f4581226a1262769d7f970e73bffe",
+                "sha256:399a0b6347bcd3822be369392932884b8216d0944049ae22925631a9b3d4ba4c",
+                "sha256:3a622ac801b17198020f09af3eaf45666b344a0d69fc2a6ffe2ea83aeef1d807",
+                "sha256:4376538f36b533b46f8971d3a3e63464f2c7905c9800db97361c43a2b14792ab",
+                "sha256:4b583b97ab2e3efe1b3e75248a9b333bd3f8b0b1b8e5b45578e05e5850dfb2c2",
+                "sha256:4b6f236edf6e2f9ae8fcd1332da4e791c1b6ba0dc16a2dc94590ceccb482e546",
+                "sha256:4da86b6d62a496e908ac2898243920c7992499c1712ff7c2b6d837cc69d9467e",
+                "sha256:50aa94fb1fb9a397eaa19c0d5ec15a5edd03a47bf1a3a6111a16b36e190cff65",
+                "sha256:567f5c155eda8df1d3d439d40a45a6a5f029b429b06648235f1e7e51b522b396",
+                "sha256:5a02d5a850e2979b0a014c412573953995174743a3f7fa4ea5a6e9a3c5617431",
+                "sha256:5e1e9802121405ede4b0133aa4340ad8186a1d2526de5b7c3eca519db7bb89fb",
+                "sha256:5f33166f0dfcce728191f520bd2692914ec70fac2713f6bf3ce59c3deacb4699",
+                "sha256:606cc265adc9aaedcc84f1f064f0e8736bc45814f15a357e30fca7ecc01504e0",
+                "sha256:635adb9a4507c9fd2ed65f39693fa31c9a3ee3a8e6dc64df033e8fdf52a7003f",
+                "sha256:65646bb0359386e07639c367a22cf9b5bf6304e8630b565d0626e2bdf329227a",
+                "sha256:67f8c5cbcd3deb7a60b3345dffc89a961a484ed0af1f6f73de91705cc6e31235",
+                "sha256:69212fbccdbd5b0e39eac4067e20a4a5256609e209547d86f740d68ad4f04911",
+                "sha256:6b8b09c1fad947c84bbbc95eca841350fad9cbfa5a2d7ca88ac9f8d836c92e23",
+                "sha256:6be8ed3039ae7f7ac5ce058c308484787c86e8437e72b30bf5e88b8ea10f3c87",
+                "sha256:6e16e07d85ca0cf8bafe5f5d23a0b850064e8e945d5677492b06bbe6f09cc699",
+                "sha256:736f227fb490f03c6488f9b6d45855f8e0fd749c007f9303ad30efab0e73c05a",
+                "sha256:73ab1601f84dc804f7812dc297e93cd99381162da39c47040a827d4e8dafe63b",
+                "sha256:77eb4c747061a6af8d0f7bdb31f1e108d172762ef579166ec84542f711d90256",
+                "sha256:78a384e49f46b80fb4c901d52d92abe098e78768ed829c673fbb53c498bef73a",
+                "sha256:7bb3b9ddb87ef7725056572368040c32775036472d5a033679d1fa6c8dc08417",
+                "sha256:7ea7c6c9d0d286d04ed3541747e6597cbe4971f22648b68248f7ddcd329207f0",
+                "sha256:7fe650342addd8524ca63d77b2362b02345e5f1a093266787d210c70a50b471a",
+                "sha256:813922f35bd800dca9994c5971883cbc0d291128a5de6b167c7aa697fcf59360",
+                "sha256:83082a57783239717ceb0ad584de3c69cf581b2a95ed6bf81ea66034f00401c0",
+                "sha256:8421e088bc051361b01c4b3a50fd39a4b9133079a2229978d9d30511fd05231b",
+                "sha256:86b0e7308289ddde73d863b7683f596d8d21c7d8664ce1dee061d0bcf3fbb4bb",
+                "sha256:88127d40df529336a9836870436fc2751c339fbaed3a836d42c93f3e4bd1d0a2",
+                "sha256:8fb190658865565c549b6b4706856d6a7b09302c797eb2cf8e7fe9dabb043f0d",
+                "sha256:912e6ebc7a6e4adfdbb1aec371ad04c68854cd3bf3608b3514e7ff9062931d8a",
+                "sha256:925a1edf3d810537c5a3abe78ec5530160c5f9a26b1f4270b40e62cc79304a1e",
+                "sha256:93c1b03552081b2a4423091d6fb3787265b8f86af404cff98d1b5342713bdd69",
+                "sha256:972b9e3a4094b053a4e46832b4bc829fc8a8d347160eb39d03f1690316a99c14",
+                "sha256:981a651f543f2854abd3b5fcb3263aac581b18209be49863ba575de6edf4c14d",
+                "sha256:99e4aa63097ab1118e75a848a28e40d68b08a5e19ce587891ab7fd04475e780f",
+                "sha256:9fa6e4dd51fe15d8738708a973470f67a855ca50002294852e9571cdbd9433f2",
+                "sha256:a0ec07fd264d0745ee396b666d47cef20875f4ff2375d7c4f58235886cc1ef0c",
+                "sha256:a2d9a3b260cc1d1dbdb1c582e63ddcf5363426a1a68faa0f5da28d8ee3c722a0",
+                "sha256:a3cc8638b2480865eaa3926d192e64ce6c51e3d29c849e09d5b4ad95efae5399",
+                "sha256:a609f9c93113be646f44c2a0256d6ea375ad047005d7f57a5c15f614dc1b2f59",
+                "sha256:a62c6ef0d50e6de320c270ff91d9dd0a05e7250cac2a800b7784bae474506e63",
+                "sha256:a6442c59a8ac8b85812ce33bc4d05bde3fb22321fa8294e2a5b487c3505f611b",
+                "sha256:a7b55a944a7f43892e28ad4bc0561dfd5f0d73e605d1aa5c3c976b52aea121d2",
+                "sha256:a8b6f03672aa6734e700bbcd65ff050fd19cddfec4b031cc8cf1c6967de5a68e",
+                "sha256:affef7c76a9ef259187ef31599a9260330e0335a3011732c4b9effa01e1cd6e0",
+                "sha256:b06f260b16ead11643a5a9f955bd4b5fd76c1a4c6796aeade8520095b75de520",
+                "sha256:b1c81d0e5e160651879755c9c675b974276f135558cf4ba79fee7b8413a515df",
+                "sha256:b281d5eca50189325cfe1f365fafade89b14b4a78d9b40b05ddd1fc7d2a10a9c",
+                "sha256:b51dcd060f18c19290d9b8a9dd1e0181538df2ce0717f562fff6cf74d9fc0b5b",
+                "sha256:b7b8288eb7cdd268b0304632da8cb0bb93fadcfec2fe5712f7b9cc8f4d487be2",
+                "sha256:b9be91986841a75042b3e3243d0b3cb0b2434252b977baaf0cd56e960fe1e46f",
+                "sha256:ba58bbcd1b72f136080c0bccc2400d66cc6115f3f906c499013d065ac33a4b61",
+                "sha256:bb45474711ba385c46a0bfe696c695a929ae69ac636cda8f532be9e8c93d720a",
+                "sha256:bc01f57ca26269c2c706e838f6422e2a8788e41b3e3c65e2f41148212e57cd59",
+                "sha256:bc91b314cef27742da486d6839b677b3f2793dfe52b51bbbb7cf736d5c29281c",
+                "sha256:bda5e34f8a75721c96085903c6f2197dc398c20ffd98df33f866a9c8fd95f4bf",
+                "sha256:c134869d5ffe34547d14e174c866fd8fe2254918cc0a95e99052903bc1543e07",
+                "sha256:c41e71c9cfb854789dee6fc51e46743a6d138b1803fab6cb860af43265b42ea6",
+                "sha256:c4e16bd7761c5e454f4efd36f345286d6f7c5fa111623c355691e2755cae3b9e",
+                "sha256:c7315339eae3b24c2d2fa1ed7d7a38654cba34a13ef19fbcb9425da46d3dc594",
+                "sha256:c79124f70465a150e89340de5963f936ee97097d2ef76c869708c4248c63ca49",
+                "sha256:cac0fdca17b036af3881a9d2729a850b76553f3f716ccb0360ad4dbc06b3b843",
+                "sha256:cc87dd1b6eaf0b848eebb1c86469b9f72a1891cb42ac7adcfbce75eadb13dd14",
+                "sha256:cce2109b6219f22ece99db7644b9622f54a4e915dad65660ec435e89a3ea7cc3",
+                "sha256:d41213ea25a86f69efd1575073d34ea11aabe075604ddf3d148ecfec9e1e96a1",
+                "sha256:dc7c389dce432500273eaf48f410b37886be9208b2dd5710aaf7c57fd442c698",
+                "sha256:dd5e856ebb7bfb7672b0086846db5afb4567a7b9714b8a0ebafd211ec7ce6a15",
+                "sha256:e1ed71194ef6dea7ed2d5cb5f7243d4bcd334bfb63e59878519be558078f848d",
+                "sha256:e201e015644e207139f7e2351980feb7040e6f4b2c2978892f3e3789d1c125e5",
+                "sha256:e28299d9f2e889e6d51b1f043f58d5f997c373cc12e6403b90df95b8b047c13e",
+                "sha256:f3c887f96407cea3916294046fc7dab611c2552beadbed4ea901cbc6a40cc7a0",
+                "sha256:f49a05acd3dfe1ce9715b657e28d138578bc40126760efb962322c56e9ca344b",
+                "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239",
+                "sha256:f51328ffe987aecf6d09f3cd9d979face89a617eacdaea43e7b3080777f647ba",
+                "sha256:f57b2a3c8353d3e04acf75b3fed57ba41f5c0646bbf1d10c7c282291c97936b4",
+                "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260",
+                "sha256:fc04cc7a3db33664e0c2d10eb8990ff6b3536f6842c9590ae8da4c614b9ed05a",
+                "sha256:fff7b9c3f19957020cac546c70025331113d2e61537f6e2441bc7657913de7d3"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==7.8.2"
+            "version": "==7.10.7"
         },
         "distlib": {
             "hashes": [
-                "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87",
-                "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"
+                "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16",
+                "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"
             ],
-            "version": "==0.3.9"
+            "version": "==0.4.0"
         },
         "exceptiongroup": {
             "hashes": [
@@ -135,19 +161,19 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2",
-                "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de"
+                "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58",
+                "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.18.0"
+            "version": "==3.19.1"
         },
         "identify": {
             "hashes": [
-                "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2",
-                "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6"
+                "sha256:11a073da82212c6646b1f39bb20d4483bfb9543bd5566fec60053c4bb309bf2e",
+                "sha256:663494103b4f717cb26921c52f8751363dc89db64364cd836a9bf1535f53cd6a"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.6.12"
+            "version": "==2.6.14"
         },
         "iniconfig": {
             "hashes": [
@@ -175,11 +201,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc",
-                "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"
+                "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85",
+                "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==4.3.8"
+            "version": "==4.4.0"
         },
         "pluggy": {
             "hashes": [
@@ -191,97 +217,110 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146",
-                "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd"
+                "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8",
+                "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==4.2.0"
+            "version": "==4.3.0"
         },
         "pygments": {
             "hashes": [
-                "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
-                "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"
+                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.19.1"
+            "version": "==2.19.2"
         },
         "pytest": {
             "hashes": [
-                "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6",
-                "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e"
+                "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01",
+                "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==8.4.0"
+            "version": "==8.4.2"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a",
-                "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde"
+                "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1",
+                "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==6.1.1"
+            "version": "==7.0.0"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff",
-                "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48",
-                "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086",
-                "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e",
-                "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133",
-                "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5",
-                "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484",
-                "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee",
-                "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5",
-                "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68",
-                "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a",
-                "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf",
-                "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99",
-                "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8",
-                "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85",
-                "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19",
-                "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc",
-                "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a",
-                "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1",
-                "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317",
-                "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c",
-                "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631",
-                "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d",
-                "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652",
-                "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5",
-                "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e",
-                "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b",
-                "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8",
-                "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476",
-                "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706",
-                "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563",
-                "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237",
-                "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b",
-                "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083",
-                "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180",
-                "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425",
-                "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e",
-                "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f",
-                "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725",
-                "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183",
-                "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab",
-                "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774",
-                "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725",
-                "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
-                "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5",
-                "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d",
-                "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290",
-                "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44",
-                "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed",
-                "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4",
-                "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba",
-                "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12",
-                "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"
+                "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c",
+                "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a",
+                "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3",
+                "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956",
+                "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6",
+                "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c",
+                "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65",
+                "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a",
+                "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0",
+                "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b",
+                "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1",
+                "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7",
+                "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e",
+                "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007",
+                "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310",
+                "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4",
+                "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9",
+                "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea",
+                "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0",
+                "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e",
+                "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac",
+                "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9",
+                "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7",
+                "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35",
+                "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb",
+                "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69",
+                "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5",
+                "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b",
+                "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c",
+                "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd",
+                "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824",
+                "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198",
+                "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065",
+                "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c",
+                "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c",
+                "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764",
+                "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196",
+                "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b",
+                "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00",
+                "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac",
+                "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8",
+                "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e",
+                "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28",
+                "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3",
+                "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5",
+                "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b",
+                "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf",
+                "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5",
+                "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702",
+                "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8",
+                "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788",
+                "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da",
+                "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d",
+                "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc",
+                "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c",
+                "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba",
+                "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917",
+                "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5",
+                "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26",
+                "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f",
+                "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b",
+                "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be",
+                "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c",
+                "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6",
+                "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926",
+                "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==6.0.2"
+            "version": "==6.0.3"
         },
         "tomli": {
             "hashes": [
@@ -324,19 +363,22 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
-                "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==4.14.0"
+            "version": "==4.15.0"
+        },
+        "tzdata": {
+            "markers": "platform_system == 'Windows'"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11",
-                "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af"
+                "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026",
+                "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==20.31.2"
+            "version": "==20.34.0"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -104,15 +104,15 @@ The `JalaliDateTime` object represents a date and time in the Jalali calendar.
 
 ```python
 >>> from persiantools.jdatetime import JalaliDateTime
->>> import datetime, pytz
+>>> import datetime
 
 # Current Jalali datetime
 >>> JalaliDateTime.now()
 JalaliDateTime(1404, 3, 16, 2, 17, 14, 907909)
 
-# Current Jalali datetime (timezone-aware)
->>> JalaliDateTime.now(pytz.timezone("Asia/Tehran"))
-JalaliDateTime(1404, 3, 16, 2, 17, 14, 907909, tzinfo=<DstTzInfo 'Asia/Tehran' +0330+3:30:00 STD>)
+>>> from zoneinfo import ZoneInfo
+>>> JalaliDateTime.now(ZoneInfo("Asia/Tehran"))
+JalaliDateTime(1404, 3, 16, 2, 17, 14, 907909, tzinfo=zoneinfo.ZoneInfo(key='Asia/Tehran'))
 
 # Current UTC Jalali datetime
 >>> JalaliDateTime.utcnow()
@@ -132,20 +132,21 @@ JalaliDateTime(1367, 2, 14, 14, 30, 15)
 JalaliDateTime(1400, 1, 1, 15, 30, 0, 10)
 
 # Timezone conversion
->>> tehran_tz = pytz.timezone("Asia/Tehran")
->>> utc_tz = pytz.utc
+>>> from zoneinfo import ZoneInfo
+>>> tehran_tz = ZoneInfo("Asia/Tehran")
+>>> utc_tz = datetime.timezone.utc
 >>> dt_utc = JalaliDateTime.now(utc_tz)
 >>> dt_tehran = dt_utc.astimezone(tehran_tz)
 >>> dt_utc
-JalaliDateTime(1404, 3, 15, 22, 54, 8, 835877, tzinfo=<UTC>)
+JalaliDateTime(1404, 3, 15, 22, 54, 8, 835877, tzinfo=datetime.timezone.utc)
 >>> dt_tehran
-JalaliDateTime(1404, 3, 16, 2, 24, 8, 835877, tzinfo=<DstTzInfo 'Asia/Tehran' +0330+3:30:00 STD>)
+JalaliDateTime(1404, 3, 16, 2, 24, 8, 835877, tzinfo=zoneinfo.ZoneInfo(key='Asia/Tehran'))
 ```
 
 #### Attributes and Methods
 
 ```python
->>> dt_obj = JalaliDateTime(1367, 2, 14, 14, 30, 15, 123, tzinfo=pytz.utc)
+>>> dt_obj = JalaliDateTime(1367, 2, 14, 14, 30, 15, 123, tzinfo=datetime.timezone.utc)
 
 >>> dt_obj.year
 1367
@@ -162,7 +163,7 @@ JalaliDateTime(1404, 3, 16, 2, 24, 8, 835877, tzinfo=<DstTzInfo 'Asia/Tehran' +0
 >>> dt_obj.microsecond
 123
 >>> dt_obj.tzinfo
-<UTC>
+datetime.timezone.utc
 
 # Date part as datetime.date (Gregorian)
 >>> dt_obj.date()
@@ -183,9 +184,9 @@ Based on python `strftime()` behavior
 
 ```python
 >>> from persiantools.jdatetime import JalaliDateTime
->>> import pytz
+>>> from zoneinfo import ZoneInfo
 
->>> dt = JalaliDateTime(1367, 2, 14, 14, 30, 0, tzinfo=pytz.timezone("Asia/Tehran"))
+>>> dt = JalaliDateTime(1367, 2, 14, 14, 30, 0, tzinfo=ZoneInfo("Asia/Tehran"))
 
 >>> dt.strftime("%Y/%m/%d %H:%M:%S")
 '1367/02/14 14:30:00'
@@ -302,6 +303,7 @@ JalaliDate(1367, 2, 14, Chaharshanbeh)
 If you find this project helpful and would like to support its continued development, please consider donating.
 
 *   **Bitcoin (BTC):** `bc1qg5rp7ymznc98wmhltzvpwl2dvfuvjr33m4hy77`
+*   **Ethereum (ETH):** `0xC7D6bf306E456632764D0aD111C8dBBb43a3B9ad`
 *   **Tron (TRX):** `TDd63bVWZDBHmwVNFgJ6T2WdWmk9z7PBLg`
 *   **Stellar (XLM):** `GDSFPPLY34QSAOTOP4DQDXAI2YDRNRIADZHTN3HCGMQXRLIGPYOEH7L5`
 *   **Solana (SOL):** `CXHKgCBqBYy1hbZKGqaSmMzQoTC4Wx2v8QfL9Z7JBo3A`

--- a/persiantools/__init__.py
+++ b/persiantools/__init__.py
@@ -7,7 +7,7 @@
 
 __title__ = "persiantools"
 __url__ = "https://github.com/majiidd/persiantools"
-__version__ = "5.3.0"
+__version__ = "5.4.0"
 __build__ = __version__
 __author__ = "Majid Hajiloo"
 __author_email__ = "majid.hajiloo@gmail.com"

--- a/persiantools/jdatetime.py
+++ b/persiantools/jdatetime.py
@@ -5,8 +5,7 @@ from datetime import datetime as dt
 from datetime import time as _time
 from datetime import timedelta, timezone, tzinfo
 from re import escape as re_escape
-
-import pytz
+from zoneinfo import ZoneInfo
 
 from persiantools import digits, utils
 
@@ -1738,7 +1737,7 @@ class JalaliDateTime(JalaliDate):
                 r"(?:[:]?(?P<zS>[0-5]\d))?"
                 r"(?:\.(?P<zf>\d{1,6}))?)"
             ),
-            "%Z": cls._seqToRE(pytz.all_timezones, "Z"),
+            "%Z": r"(?P<Z>[A-Za-z_/\-]+)",
         }
 
         fmt = utils.replace(
@@ -1787,7 +1786,10 @@ class JalaliDateTime(JalaliDate):
                 )
                 tz = timezone(delta)
             elif "Z" in directives.keys():
-                tz = pytz.timezone(directives.get("Z"))
+                try:
+                    tz = ZoneInfo(directives.get("Z"))
+                except Exception:
+                    raise ValueError(f"Unknown time zone name: {directives.get('Z')}")
 
             cls_attrs = {
                 "year": directives.get("Y", 1),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.black]
 line-length = 120
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 include = '\.pyi?$'
 exclude = '''
 (
@@ -19,9 +20,20 @@ exclude = '''
 '''
 
 [tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
+profile = "black"
 line_length = 120
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+
+[tool.mypy]
+python_version = "3.9"
+warn_unused_ignores = true
+warn_redundant_casts = true
+disallow_incomplete_defs = false
+no_implicit_optional = true
+check_untyped_defs = false
+ignore_missing_imports = false

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from setuptools import setup
 
 import persiantools

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from setuptools import setup
+import re
 
-import persiantools
+from setuptools import setup
 
 
 def readme():
@@ -8,9 +8,17 @@ def readme():
         return f.read()
 
 
+def read_version():
+    with open("persiantools/__init__.py", encoding="utf-8") as f:
+        m = re.search(r"^__version__\s*=\s*['\"]([^'\"]+)['\"]", f.read(), re.M)
+        if not m:
+            raise RuntimeError("Cannot find __version__ in persiantools/__init__.py")
+        return m.group(1)
+
+
 setup(
     name="persiantools",
-    version=persiantools.__version__,
+    version=read_version(),
     description="Jalali date and datetime with other tools",
     long_description=readme(),
     long_description_content_type="text/markdown",
@@ -36,14 +44,17 @@ setup(
     keywords="jalali shamsi persian digits characters converter jalalidate "
     "jalalidatetime date datetime jdate jdatetime farsi",
     url="https://github.com/majiidd/persiantools",
+    project_urls={
+        "Source": "https://github.com/majiidd/persiantools",
+        "Issues": "https://github.com/majiidd/persiantools/issues",
+    },
     author="Majid Hajiloo",
     author_email="majid.hajiloo@gmail.com",
     license="MIT",
     license_files=("LICENSE",),
     packages=["persiantools"],
     python_requires=">=3.9",
-    tests_require=["pytest", "pytest-cov"],
-    install_requires=["pytz"],
+    install_requires=["tzdata; platform_system == 'Windows'"],
     include_package_data=True,
     zip_safe=False,
 )

--- a/tests/test_jalalidate.py
+++ b/tests/test_jalalidate.py
@@ -33,6 +33,7 @@ class TestJalaliDate(TestCase):
             (JalaliDate(1403, 8, 18), date(2024, 11, 8)),
             (JalaliDate(1404, 3, 16), date(2025, 6, 6)),
             (JalaliDate(1403, 10, 27), date(2025, 1, 16)),
+            (JalaliDate(1404, 7, 4), date(2025, 9, 26)),
             (JalaliDate(1210, 12, 29), date(1832, 3, 19)),
             (JalaliDate(1367, 12, 29), date(1989, 3, 20)),
             (JalaliDate(1392, 12, 29), date(2014, 3, 20)),

--- a/tests/test_jalalidatetime.py
+++ b/tests/test_jalalidatetime.py
@@ -120,7 +120,7 @@ class TestJalaliDateTime(TestCase):
         self.assertEqual(JalaliDateTime(1367, 2, 14, 4, 30, 4, 4444).date(), date(1988, 5, 4))
         self.assertEqual(
             JalaliDateTime(1367, 2, 14, 4, 30, 0, 0).replace(tzinfo=timezone.utc).__repr__(),
-            "JalaliDateTime(1367, 2, 14, 4, 30, tzinfo=<UTC>)",
+            "JalaliDateTime(1367, 2, 14, 4, 30, tzinfo=datetime.timezone.utc)",
         )
         self.assertEqual(
             JalaliDateTime(1367, 2, 14, 4, 30, 4, 4444).replace(year=1395, day=3, minute=59),

--- a/tests/test_jalalidatetime.py
+++ b/tests/test_jalalidatetime.py
@@ -5,9 +5,9 @@ from datetime import date, datetime
 from datetime import time as _time
 from datetime import timedelta, timezone
 from unittest import TestCase
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 
 from persiantools.jdatetime import JalaliDate, JalaliDateTime, _is_ascii_digit
 
@@ -46,7 +46,7 @@ class TestJalaliDateTime(TestCase):
         g = JalaliDateTime.now()
         self.assertEqual(g.time(), _time(g.hour, g.minute, g.second, g.microsecond))
 
-        g = g.replace(tzinfo=pytz.timezone("America/Los_Angeles"))
+        g = g.replace(tzinfo=ZoneInfo("America/Los_Angeles"))
         self.assertEqual(
             g.timetz(),
             _time(
@@ -54,13 +54,13 @@ class TestJalaliDateTime(TestCase):
                 g.minute,
                 g.second,
                 g.microsecond,
-                pytz.timezone("America/Los_Angeles"),
+                ZoneInfo("America/Los_Angeles"),
             ),
         )
 
         self.assertEqual(
-            JalaliDateTime.fromtimestamp(578723400, pytz.utc),
-            JalaliDateTime(1367, 2, 14, 4, 30, 0, 0, pytz.utc),
+            JalaliDateTime.fromtimestamp(578723400, timezone.utc),
+            JalaliDateTime(1367, 2, 14, 4, 30, 0, 0, timezone.utc),
         )
         self.assertEqual(
             JalaliDateTime.utcfromtimestamp(578723400),
@@ -111,15 +111,15 @@ class TestJalaliDateTime(TestCase):
 
     def test_others(self):
         self.assertTrue(JalaliDateTime.fromtimestamp(time.time() - 10) <= JalaliDateTime.now())
-        self.assertEqual(JalaliDateTime(1367, 2, 14, 4, 30, 0, 0, pytz.utc).timestamp(), 578723400)
+        self.assertEqual(JalaliDateTime(1367, 2, 14, 4, 30, 0, 0, timezone.utc).timestamp(), 578723400)
         self.assertEqual(
-            JalaliDateTime.fromtimestamp(578723400, pytz.utc),
-            JalaliDateTime(1367, 2, 14, 4, 30, 0, 0, pytz.utc),
+            JalaliDateTime.fromtimestamp(578723400, timezone.utc),
+            JalaliDateTime(1367, 2, 14, 4, 30, 0, 0, timezone.utc),
         )
         self.assertEqual(JalaliDateTime(1367, 2, 14, 4, 30, 4, 4444).jdate(), JalaliDate(1367, 2, 14))
         self.assertEqual(JalaliDateTime(1367, 2, 14, 4, 30, 4, 4444).date(), date(1988, 5, 4))
         self.assertEqual(
-            JalaliDateTime(1367, 2, 14, 4, 30, 0, 0).replace(tzinfo=pytz.utc).__repr__(),
+            JalaliDateTime(1367, 2, 14, 4, 30, 0, 0).replace(tzinfo=timezone.utc).__repr__(),
             "JalaliDateTime(1367, 2, 14, 4, 30, tzinfo=<UTC>)",
         )
         self.assertEqual(
@@ -127,11 +127,11 @@ class TestJalaliDateTime(TestCase):
             JalaliDateTime(1395, 2, 3, 4, 59, 4, 4444),
         )
 
-        self.assertEqual(JalaliDateTime.now(pytz.utc).tzname(), "UTC")
+        self.assertEqual(JalaliDateTime.now(timezone.utc).tzname(), "UTC")
         self.assertIsNone(JalaliDateTime.today().tzname())
         self.assertIsNone(JalaliDateTime.today().dst())
 
-        dt = JalaliDateTime(1367, 2, 14, 4, 30, 0, 0, pytz.utc)
+        dt = JalaliDateTime(1367, 2, 14, 4, 30, 0, 0, timezone.utc)
         self.assertEqual(dt.dst(), timedelta(0))
 
         self.assertEqual(
@@ -152,11 +152,11 @@ class TestJalaliDateTime(TestCase):
         )
 
         self.assertEqual(
-            JalaliDateTime(1367, 2, 14, 4, 30, 0, 1, pytz.utc).isoformat(),
+            JalaliDateTime(1367, 2, 14, 4, 30, 0, 1, timezone.utc).isoformat(),
             "1367-02-14T04:30:00.000001+00:00",
         )
         self.assertEqual(
-            JalaliDateTime(1367, 2, 14, 4, 30, 0, 1, pytz.utc).__str__(),
+            JalaliDateTime(1367, 2, 14, 4, 30, 0, 1, timezone.utc).__str__(),
             "1367-02-14 04:30:00.000001+00:00",
         )
 
@@ -201,13 +201,13 @@ class TestJalaliDateTime(TestCase):
         self.assertTrue(JalaliDateTime(1367, 2, 14, 4, 30, 0, 0) >= datetime(1988, 5, 4, 0, 0, 0, 0))
         self.assertTrue(JalaliDateTime(1395, 4, 15, 20, 13, 59, 0) == JalaliDateTime(1395, 4, 15, 20, 13, 59, 0))
         self.assertTrue(
-            JalaliDateTime(1395, 4, 15, 20, 13, 59, 0, pytz.utc) != JalaliDateTime(1395, 4, 15, 20, 13, 59, 0)
+            JalaliDateTime(1395, 4, 15, 20, 13, 59, 0, timezone.utc) != JalaliDateTime(1395, 4, 15, 20, 13, 59, 0)
         )
 
         self.assertEqual(
-            JalaliDateTime(1395, 4, 16, 20, 14, 30, 0, pytz.utc)
-            - JalaliDateTime(1395, 4, 16, 20, 14, 30, 0, pytz.timezone("Asia/Tehran")),
-            pytz.timezone("Asia/Tehran")._utcoffset,
+            JalaliDateTime(1395, 4, 16, 20, 14, 30, 0, timezone.utc)
+            - JalaliDateTime(1395, 4, 16, 20, 14, 30, 0, ZoneInfo("Asia/Tehran")),
+            timedelta(hours=4, minutes=30),
         )
 
         self.assertFalse(JalaliDateTime(1367, 2, 14, 4, 30, 0, 0) == {"year": 1367})
@@ -233,7 +233,7 @@ class TestJalaliDateTime(TestCase):
             assert JalaliDateTime(1367, 2, 14, 4, 30, 0, 0) > date(1988, 4, 5)
 
         with pytest.raises(NotImplementedError):
-            assert JalaliDateTime(1367, 2, 14, 4, 30, 0, 0) >= pytz.utc
+            assert JalaliDateTime(1367, 2, 14, 4, 30, 0, 0) >= timezone.utc
 
         with pytest.raises(TypeError):
             assert JalaliDateTime(1367, 2, 14, 4, 30, 0, 0) >= JalaliDate(1392, 4, 5)
@@ -245,7 +245,7 @@ class TestJalaliDateTime(TestCase):
             assert JalaliDateTime(1367, 2, 14, 4, 30, 0, 0) - []
 
     def test_hash(self):
-        j1 = JalaliDateTime.today().replace(tzinfo=pytz.utc)
+        j1 = JalaliDateTime.today().replace(tzinfo=timezone.utc)
         j2 = JalaliDateTime(1369, 7, 1, 0, 0, 0, 0)
         j3 = JalaliDateTime(datetime(1990, 9, 23, 0, 0, 0, 0))
 
@@ -268,7 +268,7 @@ class TestJalaliDateTime(TestCase):
 
     def test_pickle(self):
         file = open("save.p", "wb")
-        now = JalaliDateTime.now().replace(tzinfo=pytz.timezone("Asia/Tehran"))
+        now = JalaliDateTime.now().replace(tzinfo=ZoneInfo("Asia/Tehran"))
         pickle.dump(now, file)
         file.close()
 
@@ -282,27 +282,27 @@ class TestJalaliDateTime(TestCase):
 
     def test_format(self):
         self.assertEqual(
-            JalaliDateTime(1369, 7, 1, 14, 0, 10, 0, pytz.utc).strftime("%X %p %z %Z"),
+            JalaliDateTime(1369, 7, 1, 14, 0, 10, 0, timezone.utc).strftime("%X %p %z %Z"),
             "14:00:10 PM +0000 UTC",
         )
 
         self.assertEqual(
-            JalaliDateTime(1367, 2, 14, 14, 0, 10, 0, pytz.utc).strftime("%c"),
+            JalaliDateTime(1367, 2, 14, 14, 0, 10, 0, timezone.utc).strftime("%c"),
             "Chaharshanbeh 14 Ordibehesht 1367 14:00:10",
         )
 
         self.assertEqual(
-            JalaliDateTime(1397, 11, 30, 14, 0, 10, 0, pytz.utc).strftime("%c"),
+            JalaliDateTime(1397, 11, 30, 14, 0, 10, 0, timezone.utc).strftime("%c"),
             "Seshanbeh 30 Bahman 1397 14:00:10",
         )
 
         self.assertEqual(
-            JalaliDateTime(1367, 2, 14, 11, 0, 10, 553, pytz.utc).strftime("%I:%M:%S.%f %p"),
+            JalaliDateTime(1367, 2, 14, 11, 0, 10, 553, timezone.utc).strftime("%I:%M:%S.%f %p"),
             "11:00:10.000553 AM",
         )
 
         self.assertEqual(
-            JalaliDateTime(1367, 2, 14, 14, 0, 10, 553, pytz.utc).strftime("%I:%M:%S.%f %p"),
+            JalaliDateTime(1367, 2, 14, 14, 0, 10, 553, timezone.utc).strftime("%I:%M:%S.%f %p"),
             "02:00:10.000553 PM",
         )
 
@@ -346,7 +346,7 @@ class TestJalaliDateTime(TestCase):
             JalaliDateTime.strptime("1400-01-01 02:00:10.000553 PM", "%Y-%m-%d %I:%M:%S.%f %p"),
         )
 
-        jdt = JalaliDateTime(1374, 4, 8, 16, 28, 3, 227, pytz.utc)
+        jdt = JalaliDateTime(1374, 4, 8, 16, 28, 3, 227, timezone.utc)
         self.assertEqual(jdt, JalaliDateTime.strptime(jdt.strftime("%c %f %z %Z"), "%c %f %z %Z"))
 
         jdt_utc_combined = JalaliDateTime(1374, 4, 8, 16, 28, 3, 227, timezone.utc)

--- a/tests/test_jalalidatetime.py
+++ b/tests/test_jalalidatetime.py
@@ -160,6 +160,29 @@ class TestJalaliDateTime(TestCase):
             "1367-02-14 04:30:00.000001+00:00",
         )
 
+    def test_dst_fixed_offset_zero(self):
+        jdt = JalaliDateTime(1400, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=3)))
+        assert jdt.dst() == timedelta(0)
+
+    def test_tzname_fixed_offset(self):
+        jdt = JalaliDateTime(1400, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=-4, minutes=-45)))
+        # stdlib datetime.timezone tzname format is "UTC±HH:MM"
+        assert jdt.tzname() == "UTC-04:45"
+
+    def test_strptime_Z_with_zoneinfo(self):
+        # 1402-01-01 (2023-03-21) after Iran removed DST; Asia/Tehran is fixed +03:30
+        s = "1402-01-01 12:00:00 Asia/Tehran"
+        fmt = "%Y-%m-%d %H:%M:%S %Z"
+        jdt = JalaliDateTime.strptime(s, fmt)
+        assert isinstance(jdt.tzinfo, ZoneInfo)
+        assert jdt.utcoffset() == timedelta(hours=3, minutes=30)
+
+    def test_strptime_Z_invalid_name(self):
+        s = "1400-01-01 12:00:00 Mars/Phobos"
+        fmt = "%Y-%m-%d %H:%M:%S %Z"
+        with pytest.raises(ValueError):
+            JalaliDateTime.strptime(s, fmt)
+
     def test_operators(self):
         self.assertEqual(
             JalaliDateTime(1367, 2, 14, 4, 30, 0, 0) + timedelta(days=30, seconds=15, milliseconds=1),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Switched to standard library time zones (ZoneInfo) for JalaliDateTime with improved DST/offset handling and timezone parsing.
- Bug Fixes
  - More accurate utcoffset/tzname results and clearer errors for unknown time zones.
- Documentation
  - Updated examples to use ZoneInfo; added 5.4.0 changelog; added donation info.
- Tests
  - Migrated tests to ZoneInfo and added a new Jalali-to-Gregorian case.
- Chores
  - Removed pytz dependency; added Windows-only tzdata.
  - Expanded CI matrix, added caching, and streamlined publish flow.
  - Updated linting, type checks, pre-commit hooks, and repository configs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->